### PR TITLE
feat: add an `Operation` type

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const common = require('@google-cloud/common')
 const util = require('util')
 const Cluster = require('./lib/cluster')
+const Operation = require('./lib/operation')
 
 function Container (options) {
   if (!(this instanceof Container)) {
@@ -24,6 +25,10 @@ function Container (options) {
 
 Container.prototype.cluster = function (id) {
   return new Cluster(this, id)
+}
+
+Container.prototype.operation = function (id) {
+  return new Operation(this, id)
 }
 
 util.inherits(Container, common.Service)

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -24,6 +24,8 @@ util.inherits(Cluster, common.ServiceObject)
 
 // see: https://cloud.google.com/container-engine/reference/rest/v1/projects.zones.clusters
 Cluster.prototype.create = function (name, config, callback) {
+  const self = this
+
   var query = {}
   var body = Object.assign({
     initial_node_count: 3,
@@ -53,7 +55,7 @@ Cluster.prototype.create = function (name, config, callback) {
     // var operation = self.operation(resp.name);
     // operation.metadata = resp;
 
-    callback(null, resp)
+    callback(null, resp, self.container.operation(resp.name))
   })
 }
 

--- a/lib/operation.js
+++ b/lib/operation.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const common = require('@google-cloud/common')
+const is = require('is')
+const util = require('util')
+
+function Operation (container, id) {
+  var methods = {
+    get: true,
+    getMetadata: true
+  }
+
+  common.ServiceObject.call(this, {
+    parent: container,
+    baseUrl: '/operations',
+    id: id,
+    methods: methods
+  })
+
+  this.container = container
+  this.id = id
+}
+
+util.inherits(Operation, common.ServiceObject)
+
+common.util.promisifyAll(Operation, {
+  exclude: []
+})
+
+module.exports = Operation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@npm/google-cloud-container",
+  "name": "@npm/container-engine",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -2236,14 +2236,6 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-format-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/string-format-obj/-/string-format-obj-1.1.0.tgz",
@@ -2258,6 +2250,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {


### PR DESCRIPTION
Porting `Operation` itself from `@google-cloud/common-grpc` proved
unsuccessful, so here's a feature-limited work-around.